### PR TITLE
fix: camunda-platform chart version

### DIFF
--- a/.github/workflows/chart-validate.yaml
+++ b/.github/workflows/chart-validate.yaml
@@ -34,7 +34,7 @@ jobs:
           helm lint --strict charts/*
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.13
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
       - name: Don't check version increment if there is no release label

--- a/charts/zeebe-benchmark/Chart-with-artifacthub-changes.yaml.tmp
+++ b/charts/zeebe-benchmark/Chart-with-artifacthub-changes.yaml.tmp
@@ -10,7 +10,7 @@ sources:
 dependencies:
   - name: camunda-platform
     repository: "oci://ghcr.io/camunda/helm"
-    version: "0.0.0-12.0.0-alpha1"
+    version: "0.0.0-8.7.0-alpha1"
     condition: "camunda.enabled"
   - name: prometheus-elasticsearch-exporter
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 dependencies:
   - name: camunda-platform
     repository: "oci://ghcr.io/camunda/helm"
-    version: "0.0.0-12.0.0-alpha1"
+    version: "0.0.0-8.7.0-alpha1"
     condition: "camunda-platform.enabled"
   - name: prometheus-elasticsearch-exporter
     repository: "https://prometheus-community.github.io/helm-charts"


### PR DESCRIPTION
> the tag 0.0.0-12.0.0-alpha1 has been replaced with 0.0.0-8.7.0-alpha1.

See https://camunda.slack.com/archives/C06GF0JPY68/p1732010887614309?thread_ts=1731918845.694709&cid=C06GF0JPY68

Unless the rolling version `0.0.0-snapshot-alpha` shall be preferred here? 