### PR TITLE
Address problem that ES disk fills to quickly in normal benchmarks.

### DIFF
--- a/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=60
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=60
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=benchmark-test-core:26500
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=60
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="real"

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=benchmark-test-core:26500
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=60
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -140,7 +140,7 @@ starter:
   # Starter.replicas defines how many replicas of the application should be deployed
   replicas: 1
   # Starter.rate defines with which rate process instances should be created by the starter
-  rate: 150
+  rate: 60
   # Starter.logLevel defines the logging level for the benchmark starter
   logLevel: "WARN"
   # Starter.processId defines the process ID, that should be used for creating new process instances

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -366,7 +366,7 @@ camunda-platform:
       heapSize: 3g
       persistence:
         ## @param elasticsearch.master.persistence.size
-        size: 64Gi
+        size: 128Gi
       resources:
         requests:
           cpu: 1


### PR DESCRIPTION
To address the problem with the normal benchmarks that ES disk fills to quickly which leads to backlog of unexporterd records and subsequently to fill the zeebe disk and make the partition unhealthy, this PR increases the ES disk size from 64G to 128G and reduces the PI starting rate from 150 to 60.

This is related to the changes in the exporter, as ES is filling much faster https://camunda.slack.com/archives/C05DH1F5TAR/p1736863726613569 .

Hopefully, the reducing of the PI/s rate is a temporary solution.
