### PR TITLE
fix: remove broken profiling support

### DIFF
--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -216,8 +216,6 @@ For more information about Zeebe, visit [Zeebe Overview](https://docs.camunda.io
 |-|-|-|-|
 | `zeebe` | | Configuration to configure Zeebe and Gateway | |
 | | `config` | Can be used to configure Zeebe Broker and Gateway additional without the need of overwriting all environment variables from the dependency chart. | `{}` |
-| | `profiling` | Configuration for pyroscope profiling. | |
-| | `profiling.enabled` | If true, enables the pyroscope profiling. | `false` |
 
 ## Development
 

--- a/charts/zeebe-benchmark/templates/NOTES.txt
+++ b/charts/zeebe-benchmark/templates/NOTES.txt
@@ -25,11 +25,5 @@ Other:
  * Publisher replicas={{ .Values.publisher.replicas }}
  * Timer replicas={{ .Values.timer.replicas }}
 
-{{ if .Values.zeebe.profiling.enabled }}
-Profiling enabled. Access pyroscope via port-forwarding:
-
-kubectl -n pyroscope port-forward svc/pyroscope 4040
-
-{{ end }}
 
 

--- a/charts/zeebe-benchmark/templates/benchmark-config.yaml
+++ b/charts/zeebe-benchmark/templates/benchmark-config.yaml
@@ -3,8 +3,5 @@ apiVersion: v1
 metadata:
   name: benchmark-config
   labels: {{- include "zeebe-benchmark.labels" . | nindent 4 }}
-data: 
+data:
   benchmark-config.yaml: | {{ .Values.zeebe.config | toYaml | nindent 4 }}
-  {{- if .Values.zeebe.profiling.enabled }}
-  java-opts: -javaagent:/pyroscope/pyroscope.jar
-  {{- end }}

--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: benchmark-test
     app.kubernetes.io/version: "8.2.5"
     app.kubernetes.io/managed-by: Helm
-data: 
+data:
   benchmark-config.yaml: | 
     zeebe.broker.data.disk.freeSpace.processing: 3GB
     zeebe.broker.data.disk.freeSpace.replication: 2GB

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -43,21 +43,7 @@ spec:
       imagePullSecrets:
         []
       initContainers:
-        - command:
-          - wget
-          - https://github.com/pyroscope-io/pyroscope-java/releases/latest/download/pyroscope.jar
-          - -O
-          - /pyroscope/pyroscope.jar
-          image: alpine
-          name: pyroscope
-          securityContext:
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1000
-          volumeMounts:
-          - mountPath: /pyroscope
-            name: pyroscope
+        []
       containers:
         - name: core
           image: camunda/camunda:8.7.0-alpha2
@@ -115,22 +101,6 @@ spec:
               value: INFO
             - name: ZEEBE_LOG_LEVEL
               value: DEBUG
-            - name: PYROSCOPE_SERVER_ADDRESS
-              value: http://pyroscope.pyroscope.svc.cluster.local:4040
-            - name: PYROSCOPE_APPLICATION_NAME
-              value: io.camunda.zeebe.broker
-            - name: PYROSCOPE_LOG_LEVEL
-              value: debug
-            - name: PYROSCOPE_FORMAT
-              value: jfr
-            - name: PYROSCOPE_PROFILER_EVENT
-              value: cpu
-            - name: PYROSCOPE_PROFILER_ALLOC
-              value: "0"
-            - name: PYROSCOPE_PROFILER_LOCK
-              value: "0"
-            - name: PYROSCOPE_LABELS
-              value: namespace=$(K8S_NAMESPACE), pod=$(K8S_NAME)
             - name: SPRING_CONFIG_ADDITIONALLOCATION
               value: /usr/local/camunda/config/benchmark-config.yaml
             - name: JAVA_OPTS
@@ -184,8 +154,6 @@ spec:
             - mountPath: /usr/local/camunda/config/benchmark-config.yaml
               name: benchmark-config
               subPath: benchmark-config.yaml
-            - mountPath: /pyroscope
-              name: pyroscope
             - mountPath: /usr/local/camunda/logs
               name: logs
       volumes:
@@ -202,8 +170,6 @@ spec:
             defaultMode: 492
             name: benchmark-config
           name: benchmark-config
-        - emptyDir: {}
-          name: pyroscope
         - emptyDir: {}
           name: logs
       serviceAccountName: benchmark-test-core

--- a/charts/zeebe-benchmark/test/zeebe_config_test.go
+++ b/charts/zeebe-benchmark/test/zeebe_config_test.go
@@ -34,26 +34,6 @@ func TestConfigMapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configMapTemplateTest) TestProfilingEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebe.profiling.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var javaOptions string
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-	helm.UnmarshalK8SYaml(s.T(), configmap.Data["java-opts"], &javaOptions)
-
-	// then
-	s.Require().Equal("-javaagent:/pyroscope/pyroscope.jar", javaOptions)
-}
-
 func (s *configMapTemplateTest) TestSetZeebeConfig() {
 	// given
 	options := &helm.Options{

--- a/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+++ b/charts/zeebe-benchmark/values-realistic-benchmark.yaml
@@ -231,22 +231,6 @@ camunda-platform:
         value: INFO
       - name: ZEEBE_LOG_LEVEL
         value: DEBUG
-      - name: PYROSCOPE_SERVER_ADDRESS
-        value: "http://pyroscope.pyroscope.svc.cluster.local:4040"
-      - name: PYROSCOPE_APPLICATION_NAME
-        value: "io.camunda.zeebe.broker"
-      - name: PYROSCOPE_LOG_LEVEL
-        value: "debug"
-      - name: PYROSCOPE_FORMAT
-        value: "jfr"
-      - name: PYROSCOPE_PROFILER_EVENT
-        value: "cpu"
-      - name: PYROSCOPE_PROFILER_ALLOC
-        value: "0"
-      - name: PYROSCOPE_PROFILER_LOCK
-        value: "0"
-      - name: PYROSCOPE_LABELS
-        value: "namespace=$(K8S_NAMESPACE), pod=$(K8S_NAME)"
       # To be able to load a separate/additional configuration
       # See https://github.com/camunda/camunda-platform-helm/issues/2197
       - name: SPRING_CONFIG_ADDITIONALLOCATION

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -35,7 +35,7 @@ global:
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets: [ ]
+    pullSecrets: []
   # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
   identity:
     auth:
@@ -204,10 +204,6 @@ zeebe:
     zeebe.broker.flowControl.write.enabled: "false"
     zeebe.broker.flowControl.write.limit: 4000
     zeebe.broker.flowControl.write.throttling.enabled: "false"
-  # Zeebe.profiling configuration for pyroscope profiling
-  profiling:
-    # Zeebe.profiling.enabled if true, enables the pyroscope profiling
-    enabled: false
 
 camunda-platform:
   identity:
@@ -265,7 +261,7 @@ camunda-platform:
       ## @param core.containerSecurityContext.runAsUser
       runAsUser: 1000
       capabilities:
-        add: [ "NET_ADMIN" ]
+        add: ["NET_ADMIN"]
     javaOpts: >-
       -XX:MaxRAMPercentage=25.0
       -XX:+ExitOnOutOfMemoryError
@@ -280,37 +276,15 @@ camunda-platform:
         configMap:
           name: benchmark-config
           defaultMode: 0754
-      - name: pyroscope
-        emptyDir: { }
       - name: logs
-        emptyDir: { }
+        emptyDir: {}
     ## @param core.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
     extraVolumeMounts:
       - name: benchmark-config
         mountPath: /usr/local/camunda/config/benchmark-config.yaml
         subPath: benchmark-config.yaml
-      - name: pyroscope
-        mountPath: /pyroscope
       - name: logs
         mountPath: /usr/local/camunda/logs
-    ## @param core.extraInitContainers (Deprecated - use `initContainers` instead) ExtraInitContainers can be used to set up extra init containers for the broker pods, useful for additional exporters
-    extraInitContainers:
-      - name: pyroscope
-        image: alpine
-        command: [ 'wget', 'https://github.com/pyroscope-io/pyroscope-java/releases/latest/download/pyroscope.jar', '-O', '/pyroscope/pyroscope.jar' ]
-        volumeMounts:
-          - name: pyroscope
-            mountPath: /pyroscope
-        # We have to configure the security context to not run as Root
-        securityContext:
-          ## @param securityContext.allowPrivilegeEscalation
-          allowPrivilegeEscalation: false
-          ## @param securityContext.privileged
-          privileged: false
-          ## @param securityContext.readOnlyRootFilesystem
-          readOnlyRootFilesystem: true
-          ## @param securityContext.runAsUser
-          runAsUser: 1000
     retention:
       ## @param core.retention.enabled if true, the ILM Policy is created and applied to the index templates.
       enabled: true
@@ -339,22 +313,6 @@ camunda-platform:
         value: INFO
       - name: ZEEBE_LOG_LEVEL
         value: DEBUG
-      - name: PYROSCOPE_SERVER_ADDRESS
-        value: "http://pyroscope.pyroscope.svc.cluster.local:4040"
-      - name: PYROSCOPE_APPLICATION_NAME
-        value: "io.camunda.zeebe.broker"
-      - name: PYROSCOPE_LOG_LEVEL
-        value: "debug"
-      - name: PYROSCOPE_FORMAT
-        value: "jfr"
-      - name: PYROSCOPE_PROFILER_EVENT
-        value: "cpu"
-      - name: PYROSCOPE_PROFILER_ALLOC
-        value: "0"
-      - name: PYROSCOPE_PROFILER_LOCK
-        value: "0"
-      - name: PYROSCOPE_LABELS
-        value: "namespace=$(K8S_NAMESPACE), pod=$(K8S_NAME)"
       # To be able to load a separate/additional configuration
       # See https://github.com/camunda/camunda-platform-helm/issues/2197
       - name: SPRING_CONFIG_ADDITIONALLOCATION


### PR DESCRIPTION
Our pyroscope setup was not working correctly anyway so let's remove support for it. This helps speed up installation a bit because we no longer need the init container that downloads pyroscope.