### PR TITLE
fix: truncate es name

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -90,20 +90,12 @@ data:
               url: "http://benchmark-test-elasticsearch:9200"
               index:
                 prefix: "zeebe-record"
-              retention:
-                enabled: true
-                minimumAge: "1h"
-                policyName: "core-record-retention-policy"
           CamundaExporter:
             className: "io.camunda.exporter.CamundaExporter"
             args:
               connect:
                 type: elasticsearch
                 url: "http://benchmark-test-elasticsearch:9200"
-              retention:
-                enabled: true
-                minimumAge: "1h"
-                policyName: "core-record-retention-policy"
               createSchema: true
 
     camunda:
@@ -118,10 +110,9 @@ data:
       security:
         authentication:
           method: "basic"
-          basic:
-            allowUnauthenticatedApiAccess: false
+          unprotectedApi: true
         authorizations:
-          enabled: true
+          enabled: false
         initialization:
           users:
             - username: "demo"
@@ -146,7 +137,7 @@ data:
       #
       operate:
         persistentSessionsEnabled: true
-      
+
         # ELS instance to store Operate data
         elasticsearch:
           # Operate index prefix.
@@ -174,9 +165,6 @@ data:
         zeebe:
           # Gateway address
           gatewayAddress: "benchmark-test-core:26500"
-        archiver:
-          ilmEnabled: true
-          ilmMinAgeForDeleteArchivedIndices: 1h
 
       #
       # Camunda Tasklist Configuration.
@@ -216,8 +204,5 @@ data:
           # Gateway address
           gatewayAddress: benchmark-test-core:26500
           restAddress: "http://benchmark-test-core:8080"
-        archiver:
-          ilmEnabled: true
-          ilmMinAgeForDeleteArchivedIndices: 1h
 
   log4j2.xml: |

--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -20,10 +20,9 @@ data:
 
     exec /usr/local/camunda/bin/camunda
   application.yaml: |
-    
     spring:
       profiles:
-        active: "operate,tasklist,broker,auth"
+        active: "identity,operate,tasklist,broker,consolidated-auth"
 
     management:
       server:
@@ -117,8 +116,20 @@ data:
           enabled: true
 
       security:
+        authentication:
+          method: "basic"
+          basic:
+            allowUnauthenticatedApiAccess: false
         authorizations:
-          enabled: false
+          enabled: true
+        initialization:
+          users:
+            - username: "demo"
+              password: "demo"
+              name: "Demo User"
+              email: "demo@demo.com"
+        multiTenancy:
+            enabled: false
 
       #
       # Camunda Database Configuration.

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 81feafb58f94983b12ab5e7890d39028acc3cb57e0b532b421faf9df5fd5e02a
+        checksum/config: a9b59aa43b555aa30c642d21567397c7f596f64a7490f214cdc7125ff6ea5202
     spec:
       imagePullSecrets:
         []
@@ -101,6 +101,9 @@ spec:
                   key: java-opts
                   name: zeebe-config
                   optional: true
+          envFrom:
+            - configMapRef:
+                name: benchmark-test-camunda-platform-documentstore-env-vars
           ports:
             - containerPort: 8080
               name: http

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: a9b59aa43b555aa30c642d21567397c7f596f64a7490f214cdc7125ff6ea5202
+        checksum/config: 743096a8952b2149b9dee612b9d5989ef4e153ed114a8746d191fa4b7519d8f3
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -321,6 +321,8 @@ camunda-platform:
   ## @extra elasticsearch
   elasticsearch:
     master:
+      fullnameOverride: elastic
+      nameOverride: elastic
       ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
       replicaCount: 3
       ## @param elasticsearch.master.heapSize

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -36,9 +36,10 @@ global:
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
-  # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
-  identity:
-    auth:
+  security:
+    authentication:
+      unprotectedApi: true
+    authorizations:
       enabled: false
 
 # Saas configuration to run benchmarks against Camunda SaaS environment


### PR DESCRIPTION
Restore the truncation of the names for the Elasticsearch service in the benchmark config.

closes #232
related to https://github.com/camunda/zeebe-benchmark-helm/pull/143