### PR TITLE
refactor: renamed archiver to history for camunda exporter settings

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -18,13 +18,13 @@ data:
     zeebe.broker.executionMetricsExporterEnabled: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.elsRolloverDateFormat: yyyy-MM-dd-HH
-    zeebe.broker.exporters.CamundaExporter.args.archiver.retention.enabled: "true"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.retention.minimumAge: 1h
-    zeebe.broker.exporters.CamundaExporter.args.archiver.retention.policyName: camunda-retention-policy
-    zeebe.broker.exporters.CamundaExporter.args.archiver.rolloverBatchSize: 10
-    zeebe.broker.exporters.CamundaExporter.args.archiver.rolloverInterval: 1h
-    zeebe.broker.exporters.CamundaExporter.args.archiver.waitPeriodBeforeArchiving: 1m
+    zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: yyyy-MM-dd-HH
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: 1h
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: camunda-retention-policy
+    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 10
+    zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: 1h
+    zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: 1m
     zeebe.broker.exporters.CamundaExporter.args.index.shouldWaitForImporters: false
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: yyyy-MM-dd-HH
     zeebe.broker.flowControl.write.enabled: "false"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -185,15 +185,15 @@ zeebe:
     # such that ILM can clean it up quickly
     # We need to configure it for the ES exporter AND the CamundaExporter
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: "yyyy-MM-dd-HH"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.elsRolloverDateFormat: "yyyy-MM-dd-HH"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.rolloverInterval: "1h"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.rolloverBatchSize: 10
-    zeebe.broker.exporters.CamundaExporter.args.archiver.waitPeriodBeforeArchiving: "1m"
+    zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
+    zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: "1h"
+    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 10
+    zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: "1m"
     # We moved the archiver configuration under retention at some point, but still need to support the previous
     # versions for now, so the configurations for retention are duplicated
-    zeebe.broker.exporters.CamundaExporter.args.archiver.retention.enabled: "true"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.retention.minimumAge: "1h"
-    zeebe.broker.exporters.CamundaExporter.args.archiver.retention.policyName: "camunda-retention-policy"
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: "1h"
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: "camunda-retention-policy"
     # For now, disable waiting for exporters, as ther seems to be a bug where nothing is added
     zeebe.broker.exporters.CamundaExporter.args.index.shouldWaitForImporters: false
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.


### PR DESCRIPTION
The archiver property was renamed to `history` and the enabled flag was removed

relates to https://github.com/camunda/camunda/issues/29386