### PR TITLE
Configure retention for exporters

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -90,12 +90,27 @@ data:
               url: "http://benchmark-test-elasticsearch:9200"
               index:
                 prefix: "zeebe-record"
+              retention:
+                enabled: true
+                minimumAge: "1h"
+                policyName: "core-record-retention-policy"
           CamundaExporter:
             className: "io.camunda.exporter.CamundaExporter"
             args:
               connect:
                 type: elasticsearch
                 url: "http://benchmark-test-elasticsearch:9200"
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+                retention:
+                  enabled: true
+                  minimumAge: "1h"
+                  policyName: "core-record-retention-policy"
               createSchema: true
 
     camunda:
@@ -165,6 +180,9 @@ data:
         zeebe:
           # Gateway address
           gatewayAddress: "benchmark-test-core:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1h
 
       #
       # Camunda Tasklist Configuration.
@@ -204,5 +222,8 @@ data:
           # Gateway address
           gatewayAddress: benchmark-test-core:26500
           restAddress: "http://benchmark-test-core:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1h
 
   log4j2.xml: |

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 743096a8952b2149b9dee612b9d5989ef4e153ed114a8746d191fa4b7519d8f3
+        checksum/config: d0d2b8be6fdcdfc9c9e5754eb525c05ecd8907ab000e97e830cfa9534976b4ac
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -286,11 +286,12 @@ camunda-platform:
         subPath: benchmark-config.yaml
       - name: logs
         mountPath: /usr/local/camunda/logs
-    retention:
-      ## @param core.retention.enabled if true, the ILM Policy is created and applied to the index templates.
-      enabled: true
-      ## @param core.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
-      minimumAge: 1h
+    history:
+      retention:
+        ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+        enabled: true
+        ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+        minimumAge: 1h
     # @param core.env can be used to set extra environment variables in each broker container
     env:
       # Enable JSON logging for google cloud stackdriver


### PR DESCRIPTION
The retention configurations got changed. These are now under `core.history.retention`. I've changed them here accordingly.

See: https://github.com/camunda/camunda/blob/5bf070046d38e0f234335111fdcca6c2aaea593d/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java#L19
and: https://github.com/camunda/camunda-platform-helm/pull/3169

closes #235 