### PR TITLE
Move to a stable camunda-platform version

### DIFF
--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -9,8 +9,8 @@ sources:
   - https://github.com/camunda/camunda
 dependencies:
   - name: camunda-platform
-    repository: "oci://ghcr.io/camunda/helm"
-    version: "0.0.0-rc-alpha-8.8"
+    repository: "https://helm.camunda.io"
+    version: "13.0.0-alpha2"
     condition: "camunda-platform.enabled"
   - name: prometheus-elasticsearch-exporter
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: d0d2b8be6fdcdfc9c9e5754eb525c05ecd8907ab000e97e830cfa9534976b4ac
+        checksum/config: cbb5db66295c67fa2f818d0cadd937f8c9308a59b2eef7b142bbadf00e3a2730
     spec:
       imagePullSecrets:
         []


### PR DESCRIPTION
## Description

Finally a stable alpha version of 8.8 got released 🎉 I have upgraded the camunda platform chart to 13.0.0-alpha2. Note that I had to also change the repository, as alpha charts are now published on the helm repo used by our customers.

closes #234