### PR TITLE
Add short description on how to run the benchmark against saas.

### DIFF
--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -73,6 +73,29 @@ and much closer to production systems.
 For more details, follow the Camunda Platform 8
 [local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/).
 
+### Running against Saas
+
+If you want to run the helm Benchmark against a Camunda Saas 
+cluster you need to run through the following steps:
+
+1. Create a new API client in the intended cluster.
+2. From the environment vars in the newly created client we need to copy the 
+   following to our `values.yaml` under `saas.credentials`.
+```yaml
+saas.credentials:
+    clientId: ZEEBE_CLIENT_ID 
+    clientSecret: ZEEBE_CLIENT_SECRET 
+    zeebeAddress: ZEEBE_ADDRESS
+    authServer: ZEEBE_AUTHORIZATION_SERVER_URL
+```
+3. Set `saas.enabled` to true. 
+4. Run the helm installation normally.
+
+This will deploy the processes used in the benchmark in the cluster and 
+then the starter will create a fixed amount of new process instances per 
+second. Optionally we can adjust the starter rate of PIs per second under 
+`starter.rate`.
+
 ## Uninstalling Charts
 
 You can remove these charts by running:

--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -75,19 +75,13 @@ For more details, follow the Camunda Platform 8
 
 ### Running against Saas
 
-If you want to run the helm Benchmark against a Camunda Saas 
-cluster you need to run through the following steps:
+If you want to run the helm Benchmark against a Camunda Saas, or other 
+Camunda kubernetes deployment (such as in Google cloud, AWS etc.), you 
+need to run through the following steps:
 
 1. Create a new API client in the intended cluster.
-2. From the environment vars in the newly created client we need to copy the 
-   following to our `values.yaml` under `saas.credentials`.
-```yaml
-saas.credentials:
-    clientId: ZEEBE_CLIENT_ID 
-    clientSecret: ZEEBE_CLIENT_SECRET 
-    zeebeAddress: ZEEBE_ADDRESS
-    authServer: ZEEBE_AUTHORIZATION_SERVER_URL
-```
+2. From the environment vars in the newly created client we need to copy 
+   them to our `values.yaml` under `saas.credentials` [here](https://github.com/camunda/zeebe-benchmark-helm/blob/751c7b35e8041da9c5e7a75232cb4d43942e6ac3/charts/zeebe-benchmark/values.yaml#L45-L78).
 3. Set `saas.enabled` to true. 
 4. Run the helm installation normally.
 


### PR DESCRIPTION
Recently there were requests from other teams not familiar with the repo to explain how to run the benchmarks against saas, and there were no resources to point to. We should have a short explanation in the read.me on how to perform this and to inform readers that this is possible.

This PR adds these steps and explains how to adjust PI creation rate in the starter.

 closed: https://github.com/camunda/zeebe-benchmark-helm/issues/243