### PR TITLE
Reduce load in starter and change default configs to reduce slow Archiver impact

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   benchmark-config.yaml: | 
+    camunda.operate.elasticsearch.numberOfShards: 3
     camunda.operate.importerEnabled: "false"
     camunda.tasklist.importerEnabled: "false"
     zeebe.broker.data.disk.freeSpace.processing: 3GB
@@ -22,7 +23,7 @@ data:
     zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
     zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: 1h
     zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: camunda-retention-policy
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 10
+    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 300
     zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: 1h
     zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: 1m
     zeebe.broker.exporters.CamundaExporter.args.index.shouldWaitForImporters: false

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=50
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=50
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=benchmark-test-core:26500
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=50
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="real"

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=benchmark-test-core:26500
-                -Dapp.starter.rate=150
+                -Dapp.starter.rate=50
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -187,7 +187,7 @@ zeebe:
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: "yyyy-MM-dd-HH"
     zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
     zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: "1h"
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 10
+    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 300
     zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: "1m"
     # We moved the archiver configuration under retention at some point, but still need to support the previous
     # versions for now, so the configurations for retention are duplicated
@@ -203,6 +203,7 @@ zeebe:
     # Disable the importers
     camunda.tasklist.importerEnabled: "false"
     camunda.operate.importerEnabled: "false"
+    camunda.operate.elasticsearch.numberOfShards: 3
 
 camunda-platform:
   identity:

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -130,7 +130,7 @@ starter:
   # Starter.replicas defines how many replicas of the application should be deployed
   replicas: 1
   # Starter.rate defines with which rate process instances should be created by the starter
-  rate: 150
+  rate: 50
   # Starter.logLevel defines the logging level for the benchmark starter
   logLevel: "WARN"
   # Starter.processId defines the process ID, that should be used for creating new process instances


### PR DESCRIPTION
Due to the benchmarks being down recently due to slow exporting which is caused by slow archiving, we want to prioritise maintaining the weekly benchmarks before this issue is fixed. 

This PR reduces the starter rate to 50 (from 150), sets in the exporter `rolloverBatchSize` to 300, and the `numberOfShards` in operate to 3.

For more details: https://camunda.slack.com/archives/C08D74J6HUG/p1740757986906249?thread_ts=1740412731.557659&cid=C08D74J6HUG