### PR TITLE
Move exporter configs to correct path. 

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -19,13 +19,6 @@ data:
     zeebe.broker.executionMetricsExporterEnabled: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
-    zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: yyyy-MM-dd-HH
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: 1h
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: camunda-retention-policy
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 300
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: 1h
-    zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: 1m
     zeebe.broker.exporters.CamundaExporter.args.index.shouldWaitForImporters: false
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: yyyy-MM-dd-HH
     zeebe.broker.flowControl.write.enabled: "false"

--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -93,7 +93,7 @@ data:
               retention:
                 enabled: true
                 minimumAge: "1h"
-                policyName: "core-record-retention-policy"
+                policyName: "camunda-retention-policy"
           CamundaExporter:
             className: "io.camunda.exporter.CamundaExporter"
             args:
@@ -101,16 +101,16 @@ data:
                 type: elasticsearch
                 url: "http://benchmark-test-elasticsearch:9200"
               history:
-                elsRolloverDateFormat: "date"
-                rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                elsRolloverDateFormat: "yyyy-MM-dd-HH"
+                rolloverInterval: "1h"
+                rolloverBatchSize: 300
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
                 retention:
                   enabled: true
                   minimumAge: "1h"
-                  policyName: "core-record-retention-policy"
+                  policyName: "camunda-retention-policy"
               createSchema: true
 
     camunda:

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: cbb5db66295c67fa2f818d0cadd937f8c9308a59b2eef7b142bbadf00e3a2730
+        checksum/config: 604e22d309ce57e8dfbe5162bc4e2e5b64316d6ce93631e5e22f39d7e6f857d1
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -185,15 +185,6 @@ zeebe:
     # such that ILM can clean it up quickly
     # We need to configure it for the ES exporter AND the CamundaExporter
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: "yyyy-MM-dd-HH"
-    zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: "1h"
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 300
-    zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: "1m"
-    # We moved the archiver configuration under retention at some point, but still need to support the previous
-    # versions for now, so the configurations for retention are duplicated
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: "1h"
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: "camunda-retention-policy"
     # For now, disable waiting for exporters, as ther seems to be a bug where nothing is added
     zeebe.broker.exporters.CamundaExporter.args.index.shouldWaitForImporters: false
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
@@ -288,11 +279,16 @@ camunda-platform:
       - name: logs
         mountPath: /usr/local/camunda/logs
     history:
+      elsRolloverDateFormat: yyyy-MM-dd-HH
+      rolloverBatchSize: 300
+      rolloverInterval: 1h
+      waitPeriodBeforeArchiving: 1m
       retention:
         ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
         enabled: true
         ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
         minimumAge: 1h
+        policyName: camunda-retention-policy
     # @param core.env can be used to set extra environment variables in each broker container
     env:
       # Enable JSON logging for google cloud stackdriver


### PR DESCRIPTION
This PR moves some of the ES exporter configuration in `values.yaml` from `zeebe.broker.exporters.CamundaExporter.args.history` to `core.history`, because that's the place where our charts are picking these configs to the configmaps.

https://github.com/camunda/camunda-platform-helm/blob/a75fed7a7004a2e134ddd5d2e99a2f975c3a9a82/charts/camunda-platform-alpha-8.8/templates/core/configmap.yaml#L177-L187

```
                elsRolloverDateFormat: {{ .Values.core.history.elsRolloverDateFormat | quote }}
                rolloverInterval: {{ .Values.core.history.rolloverInterval | quote }}
                rolloverBatchSize: {{ .Values.core.history.rolloverBatchSize }}
                waitPeriodBeforeArchiving: {{ .Values.core.history.waitPeriodBeforeArchiving | quote }}
                delayBetweenRuns: {{ .Values.core.history.delayBetweenRuns }}
                maxDelayBetweenRuns: {{ .Values.core.history.maxDelayBetweenRuns }}
              {{- if .Values.core.history.retention.enabled }}
                retention:
                  enabled: true
                  minimumAge: {{ .Values.core.history.retention.minimumAge | quote }}
                  policyName: {{ .Values.core.history.retention.policyName | quote }}
```

The changes were tested locally creating new benchmarks.