### PR TITLE
fix: set retention in camunda.database

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 data:
   benchmark-config.yaml: | 
+    camunda.database.retention.enabled: "true"
+    camunda.database.retention.minimumAge: 0s
+    camunda.database.retention.policyName: camunda-retention-policy
     camunda.operate.elasticsearch.numberOfShards: 3
     camunda.operate.importerEnabled: "false"
     camunda.tasklist.importerEnabled: "false"
@@ -21,7 +24,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: yyyy-MM-dd-HH
     zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: 1h
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: 0s
     zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: camunda-retention-policy
     zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 300
     zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: 1h

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -192,7 +192,9 @@ zeebe:
     # We moved the archiver configuration under retention at some point, but still need to support the previous
     # versions for now, so the configurations for retention are duplicated
     zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: "1h"
+    # 0s causes ILM to move data asap - it is normally the default
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: "0s"
     zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: "camunda-retention-policy"
     # For now, disable waiting for exporters, as ther seems to be a bug where nothing is added
     zeebe.broker.exporters.CamundaExporter.args.index.shouldWaitForImporters: false
@@ -204,6 +206,12 @@ zeebe:
     camunda.tasklist.importerEnabled: "false"
     camunda.operate.importerEnabled: "false"
     camunda.operate.elasticsearch.numberOfShards: 3
+    # Schema management has been moved out of exporter - to be bootstrap at start; once
+    camunda.database.retention.enabled: "true"
+    # 0s causes ILM to move data asap - it is normally the default
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+    camunda.database.retention.minimumAge: "0s"
+    camunda.database.retention.policyName: "camunda-retention-policy"
 
 camunda-platform:
   identity:


### PR DESCRIPTION
 * Schema management has been moved out of exporter - to be bootstrap at start; once
 * With that also retention and ILM policy creation has been moved

![2025-04-07_09-17](https://github.com/user-attachments/assets/5da6c6bd-6ac3-40c1-b4b7-25a9d58749c5)
