### PR TITLE
feat: add NMT and enable camunda custom jfr metrics

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -14,6 +14,7 @@ data:
     camunda.database.retention.enabled: "true"
     camunda.database.retention.minimumAge: 0s
     camunda.database.retention.policyName: camunda-retention-policy
+    camunda.flags.jfr.metrics: "true"
     camunda.operate.elasticsearch.numberOfShards: 3
     camunda.operate.importerEnabled: "false"
     camunda.tasklist.importerEnabled: "false"

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -76,7 +76,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
             - name: K8S_POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -212,6 +212,8 @@ zeebe:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
     camunda.database.retention.minimumAge: "0s"
     camunda.database.retention.policyName: "camunda-retention-policy"
+    #Metrics:
+    camunda.flags.jfr.metrics: "true"
 
 camunda-platform:
   identity:
@@ -278,6 +280,7 @@ camunda-platform:
       -XX:+HeapDumpOnOutOfMemoryError
       -XX:HeapDumpPath=/usr/local/camunda/data
       -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log
+      -XX:NativeMemoryTracking=summary
       -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M
 
     # Zeebe config


### PR DESCRIPTION
Enable NMT in  "lightweight" mode  with ` -XX:NativeMemoryTracking=summary` and camunda's new jfr metrics to expose the native memory tracking metrics in prometheus.

Flag was introduced in camunda/camunda#31018