### PR TITLE
Increase normal benchmark default load

### DIFF
--- a/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.starter.rate=50
+                -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.starter.rate=50
+                -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=benchmark-test-core:26500
-                -Dapp.starter.rate=50
+                -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="real"

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -26,7 +26,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl=benchmark-test-core:26500
-                -Dapp.starter.rate=50
+                -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.starter.processId="benchmark"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -130,7 +130,7 @@ starter:
   # Starter.replicas defines how many replicas of the application should be deployed
   replicas: 1
   # Starter.rate defines with which rate process instances should be created by the starter
-  rate: 50
+  rate: 150
   # Starter.logLevel defines the logging level for the benchmark starter
   logLevel: "WARN"
   # Starter.processId defines the process ID, that should be used for creating new process instances


### PR DESCRIPTION
We were able to show that our current main can withstand a higher load again (of 150 PIs, back to normal). This allows us to bring back the default of the starters.

![2025-05-05_16-30](https://github.com/user-attachments/assets/3c0178a9-d0be-4f7b-b493-1c673376e63b)
