### PR TITLE
Bring SSD and other settings back

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -173,6 +173,8 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      nodeSelector:
+        cloud.google.com/gke-nodepool: n2-standard-4
 # yamllint disable
       affinity:
         podAntiAffinity:
@@ -192,6 +194,7 @@ spec:
           {}
       spec:
         accessModes: [ReadWriteOnce]
+        storageClassName: ssd
         resources:
           requests:
             storage: "64Gi"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -262,6 +262,9 @@ camunda-platform:
         memory: 12Gi
     ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
     pvcSize: "64Gi"
+    ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
+    # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+    pvcStorageClassName: "ssd"
     # @extra core.containerSecurityContext defines the security options the container should be run with
     containerSecurityContext:
       ## @param core.containerSecurityContext.allowPrivilegeEscalation
@@ -344,6 +347,8 @@ camunda-platform:
       persistence:
         ## @param elasticsearch.master.persistence.size
         size: 128Gi
+        storageClass: "ssd"
+        accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
           cpu: 1

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -260,6 +260,10 @@ camunda-platform:
       limits:
         cpu: 2000m
         memory: 12Gi
+
+    nodeSelector:
+      cloud.google.com/gke-nodepool: n2-standard-2
+
     ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
     pvcSize: "64Gi"
     ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -262,7 +262,7 @@ camunda-platform:
         memory: 12Gi
 
     nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-2
+      cloud.google.com/gke-nodepool: n2-standard-4
 
     ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
     pvcSize: "64Gi"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -346,6 +346,8 @@ camunda-platform:
       nameOverride: elastic
       ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
       replicaCount: 3
+      pdb:
+        minAvailable: 2
       ## @param elasticsearch.master.heapSize
       heapSize: 3g
       persistence:


### PR DESCRIPTION
Due [to recent refactorings and changes](https://github.com/camunda/zeebe-benchmark-helm/pull/213/files#diff-6d8e2ff7ac2a07b94bd219e3231be93610964969ffb473f0135a96f7b8f8cddf) we lost some important configurations related to the storage class and node selector.

**This PR sets:**

 * The storage class again to SSD, as per default HDD are used and have unreliable latency and cause performance regressions https://github.com/camunda/camunda/issues/31702
 * Sets the node selector to small nodes, to make sure we run on a single node (1-1 mapping). Avoids the noisy neighbor syndrom
 * Correctly sets the elasticsearch minimal disruption budget, so we make sure there are always 2 nodes available (we had this before as well)


closes https://github.com/camunda/camunda/issues/31702

**Benchmarks**

I [have run a load test](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1&var-DS_PROMETHEUS=prometheus&var-cluster=All&var-namespace=ck-bring-back&var-pod=All&var-partition=All&var-memory_state=committed&from=1747660409081&to=1747661537838) for a little time, to compare with the weekly load test ([week 21](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1&var-DS_PROMETHEUS=prometheus&var-cluster=All&var-namespace=medic-y-2025-cw-21-f3fd37c7-benchmark&var-pod=All&var-partition=All&var-memory_state=committed&from=now-1h&to=now))

It shows that:

 * the throughput is much more stable
 * the p99 process completion latency has decreased by factor 10
 * the p99 commit latency has decreased by huge factor (100+)


![2025-05-19_15-36](https://github.com/user-attachments/assets/471871ee-88d7-4254-bfa1-3311c3cd3724)
![2025-05-19_15-34](https://github.com/user-attachments/assets/d8e5c008-38fe-4df6-836d-94d00f3f2b1f)
![2025-05-19_15-33](https://github.com/user-attachments/assets/6a49dc9b-1085-440a-beb5-bae0442458b1)

