### PR TITLE
fix: disable identity

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -137,9 +137,6 @@ data:
               email: "demo@demo.com"
         multiTenancy:
             enabled: false
-      identity:
-        clientId: "core"
-        audience: "core-api"
 
       #
       # Camunda Database Configuration.
@@ -160,8 +157,6 @@ data:
       #
       operate:
         persistentSessionsEnabled: true
-        identity:
-          redirectRootUrl: "http://localhost:8082/operate"
 
         # ELS instance to store Operate data
         elasticsearch:
@@ -198,8 +193,6 @@ data:
       # Camunda Tasklist Configuration.
       #
       tasklist:
-        identity:
-          redirectRootUrl: "http://localhost:8082/tasklist"
 
         # Set Tasklist username and password.
         # If user with <username> does not exists it will be created.

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: c3a3c9484582cb17cc24a466a0bb8fce6d52aa455aa936bcef7ceaaf04334851
+        checksum/config: e4b34b404bcdaf2ee038c4df7d0246f14796fb0f9273f6838c59c6ac6250bd03
     spec:
       imagePullSecrets:
         []
@@ -75,11 +75,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: VALUES_CAMUNDA_CORE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: to-be-removed
-                  key: identity-core-client-token
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
             - name: K8S_POD_NAME

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -41,12 +41,9 @@ global:
       unprotectedApi: true
     authorizations:
       enabled: false
-  # To be removed once https://github.com/camunda/camunda-platform-helm/issues/3478 is resolved
   identity:
     auth:
-      core:
-        existingSecret:
-          name: "to-be-removed"
+      enabled: false
 
 # Saas configuration to run benchmarks against Camunda SaaS environment
 saas:


### PR DESCRIPTION
The workaround made in https://github.com/camunda/zeebe-benchmark-helm/pull/261 to skip the error
```
[camunda][error]
DEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer automatically generate passwords for the Identity component.
Users must provide passwords as Kubernetes secrets.

The following values inside your values.yaml need to be set but were not:
 global.identity.auth.core.existingSecret.name

```

requires creating a secret 

```
4m53s (x857 over 3h19m)   Warning   Failed                 Pod/hb-schema-test-zeebe-2           Error: secret "to-be-removed" not found
```

With the help of @hamza-m-masood , we figured out that we can simply set the value `global.identity.auth.enabled=false`