### PR TITLE
ci: add prepare release workflow

### DIFF
--- a/.github/workflows/chart-prepare-release.yaml
+++ b/.github/workflows/chart-prepare-release.yaml
@@ -1,0 +1,19 @@
+name: "Chart - Prepare Release"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run release chores
+        run: make release.chores

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,9 @@ release.generate-pr-url:
 	@echo "\n\n###################################\n"
 	@echo "Open the release PR using this URL:"
 	@echo "https://github.com/camunda/zeebe-benchmark-helm/compare/release?expand=1&template=release_template.md&title=Release%20Zeebe%20Benchmark%20Helm%20Chart%20v$(chartVersion)"
-	xdg-open "https://github.com/camunda/zeebe-benchmark-helm/compare/release?expand=1&template=release_template.md&title=Release%20Zeebe%20Benchmark%20Helm%20Chart%20v$(chartVersion)"
+	@if [ "$$CI" != "true" ]; then \
+	  xdg-open "https://github.com/camunda/zeebe-benchmark-helm/compare/release?expand=1&template=release_template.md&title=Release%20Zeebe%20Benchmark%20Helm%20Chart%20v$(chartVersion)"; \
+	fi
 	@echo "\n###################################\n\n"
 
 .PHONY: release.chores

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,6 +38,12 @@ This action will:
 - Push updated `release` branch to the repo.
 - Generate a link to open a PR with prefilled title and template.
 
+> [!Note]
+>
+> If you are using macOS or Windows, the `make release.chores` command might not work as expected.
+> Instead, you can run the [Chart - Prepare Release](https://github.com/camunda/zeebe-benchmark-helm/actions/workflows/chart-prepare-release.yaml) workflow.
+> The link to open the pull request will be shown in the workflow logs.
+
 Next, all that you need to open the PR using the generated link and follow th checklist there.
 
 > **Note**


### PR DESCRIPTION
Alternative for macOS and Windows users as the `make release.chores` command does not work as expected.
The job is tested here https://github.com/camunda/zeebe-benchmark-helm/actions/runs/15569867040