### PR TITLE
Smaller life-enriching measures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,12 @@ helm.uninstall:
 	-kubectl delete pvc -l app.kubernetes.io/instance=$(releaseName)
 	-kubectl delete pvc -l release=$(releaseName)
 
+# helm.clean: cleans the resources deployed by the previous chart
+.PHONY: helm.clean
+helm.clean:
+	-kubectl delete pvc -l app.kubernetes.io/name=elasticsearch
+	-kubectl delete pvc -l app=camunda-platform
+
 # helm.dry-run: run an install dry-run with the local chart
 .PHONY: helm.dry-run
 helm.dry-run: helm.dependency-update

--- a/charts/zeebe-benchmark/templates/leader-balancing-cron.yaml
+++ b/charts/zeebe-benchmark/templates/leader-balancing-cron.yaml
@@ -18,6 +18,6 @@ spec:
           containers:
             - image: "curlimages/curl:7.87.0"
               name: curl
-              args: ["-L", "-v", "-X", "POST", "http://{{ .Release.Name }}-core:9600/actuator/rebalance"]
+              args: ["-L", "-v", "-X", "POST", "http://camunda:9600/actuator/rebalance"]
           restartPolicy: OnFailure
 {{- end }}

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -26,8 +26,8 @@ spec:
                 {{- if $.Values.saas.enabled }}
                 -Dapp.tls=true
                 {{- else }}
-                -Dapp.brokerUrl=http://{{ $.Release.Name }}-core:26500
-                -Dapp.brokerRestUrl=http://{{ $.Release.Name }}-core:8080
+                -Dapp.brokerUrl=http://camunda:26500
+                -Dapp.brokerRestUrl=http://camunda:8080
                 {{- end }}
                 -Dapp.preferRest={{ .Values.global.preferRest.enabled }}
                 -Dapp.starter.rate={{ .Values.starter.rate }}

--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -27,8 +27,8 @@ spec:
                 {{- if $.Values.saas.enabled }}
                 -Dapp.tls=true
                 {{- else }}
-                -Dapp.brokerUrl=http://{{ $.Release.Name }}-core:26500
-                -Dapp.brokerRestUrl=http://{{ $.Release.Name }}-core:8080
+                -Dapp.brokerUrl=http://camunda:26500
+                -Dapp.brokerRestUrl=http://camunda:8080
                 {{- end }}
                 -Dapp.preferRest={{ $.Values.global.preferRest.enabled }}
                 -Dzeebe.client.requestTimeout=62000

--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -2,22 +2,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $workerName }}-worker
+  name: {{ $workerName }}
   labels:
-    app: {{ $workerName }}-worker
+    app: {{ $workerName }}
 spec:
   selector:
     matchLabels:
-      app: {{ $workerName }}-worker
+      app: {{ $workerName }}
   replicas: {{ $worker.replicas | default 3}}
   template:
     metadata:
       labels:
-        app: {{ $workerName }}-worker
+        app: {{ $workerName }}
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:
-        - name: {{ $workerName }}-worker
+        - name: {{ $workerName }}
           image: "{{ $.Values.global.image.repository }}/worker:{{ $.Values.global.image.tag }}"
           imagePullPolicy: {{ $.Values.global.image.pullPolicy }}
           env:

--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -2,7 +2,7 @@
 # Source: zeebe-benchmark/charts/camunda-platform/templates/core/configmap.yaml
 kind: ConfigMap
 metadata:
-  name: benchmark-test-core-configuration
+  name: camunda-configuration
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -184,7 +184,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "benchmark-test-core:26500"
+          gatewayAddress: "camunda:26500"
         archiver:
           ilmEnabled: true
           ilmMinAgeForDeleteArchivedIndices: 1h
@@ -225,8 +225,8 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: benchmark-test-core:26500
-          restAddress: "http://benchmark-test-core:8080"
+          gatewayAddress: camunda:26500
+          restAddress: "http://camunda:8080"
         archiver:
           ilmEnabled: true
           ilmMinAgeForDeleteArchivedIndices: 1h

--- a/charts/zeebe-benchmark/test/golden/c8-core-service.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-service.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: benchmark-test-core
+  name: camunda
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: core
-  serviceName: benchmark-test-core
+  serviceName: camunda
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: core
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: e4b34b404bcdaf2ee038c4df7d0246f14796fb0f9273f6838c59c6ac6250bd03
+        checksum/config: f92e32442b0c0f270b5057593663f11e0dc4d9eae842245f1457a0a108013547
     spec:
       imagePullSecrets:
         []
@@ -70,7 +70,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: K8S_SERVICE_NAME
-              value: benchmark-test-core
+              value: camunda
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -154,7 +154,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: benchmark-test-core-configuration
+            name: camunda-configuration
             defaultMode: 492
         - name: exporters
           emptyDir: {}
@@ -167,7 +167,7 @@ spec:
           name: benchmark-config
         - emptyDir: {}
           name: logs
-      serviceAccountName: benchmark-test-core
+      serviceAccountName: camunda
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
@@ -3,22 +3,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: benchmark-worker
+  name: worker
   labels:
-    app: benchmark-worker
+    app: worker
 spec:
   selector:
     matchLabels:
-      app: benchmark-worker
+      app: worker
   replicas: 3
   template:
     metadata:
       labels:
-        app: benchmark-worker
+        app: worker
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:
-        - name: benchmark-worker
+        - name: worker
           image: "gcr.io/zeebe-io/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
@@ -32,7 +32,7 @@ spec:
                 -Dapp.worker.threads=10
                 -Dapp.worker.pollingDelay=1ms
                 -Dapp.worker.completionDelay=50ms
-                -Dapp.worker.workerName="benchmark"
+                -Dapp.worker.workerName="worker"
                 -Dapp.worker.jobType="benchmark-task"
                 -Dapp.worker.payloadPath="bpmn/typical_payload.json"
                 -XX:+HeapDumpOnOutOfMemoryError

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
@@ -3,22 +3,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: benchmark-worker
+  name: worker
   labels:
-    app: benchmark-worker
+    app: worker
 spec:
   selector:
     matchLabels:
-      app: benchmark-worker
+      app: worker
   replicas: 3
   template:
     metadata:
       labels:
-        app: benchmark-worker
+        app: worker
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:
-        - name: benchmark-worker
+        - name: worker
           image: "gcr.io/zeebe-io/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
@@ -32,7 +32,7 @@ spec:
                 -Dapp.worker.threads=10
                 -Dapp.worker.pollingDelay=1ms
                 -Dapp.worker.completionDelay=50ms
-                -Dapp.worker.workerName="benchmark"
+                -Dapp.worker.workerName="worker"
                 -Dapp.worker.jobType="benchmark-task"
                 -Dapp.worker.payloadPath="bpmn/typical_payload.json"
                 -XX:+HeapDumpOnOutOfMemoryError

--- a/charts/zeebe-benchmark/test/golden/leader-balancing-cron.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/leader-balancing-cron.golden.yaml
@@ -22,5 +22,5 @@ spec:
           containers:
             - image: "curlimages/curl:7.87.0"
               name: curl
-              args: ["-L", "-v", "-X", "POST", "http://benchmark-test-core:9600/actuator/rebalance"]
+              args: ["-L", "-v", "-X", "POST", "http://camunda:9600/actuator/rebalance"]
           restartPolicy: OnFailure

--- a/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
@@ -25,8 +25,8 @@ spec:
             - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dconfig.override_with_env_vars=true
-                -Dapp.brokerUrl=http://benchmark-test-core:26500
-                -Dapp.brokerRestUrl=http://benchmark-test-core:8080
+                -Dapp.brokerUrl=http://camunda:26500
+                -Dapp.brokerRestUrl=http://camunda:8080
                 -Dapp.preferRest=false
                 -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -25,8 +25,8 @@ spec:
             - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dconfig.override_with_env_vars=true
-                -Dapp.brokerUrl=http://benchmark-test-core:26500
-                -Dapp.brokerRestUrl=http://benchmark-test-core:8080
+                -Dapp.brokerUrl=http://camunda:26500
+                -Dapp.brokerRestUrl=http://camunda:8080
                 -Dapp.preferRest=false
                 -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0

--- a/charts/zeebe-benchmark/test/golden/workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/workers.golden.yaml
@@ -25,8 +25,8 @@ spec:
             - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dconfig.override_with_env_vars=true
-                -Dapp.brokerUrl=http://benchmark-test-core:26500
-                -Dapp.brokerRestUrl=http://benchmark-test-core:8080
+                -Dapp.brokerUrl=http://camunda:26500
+                -Dapp.brokerRestUrl=http://camunda:8080
                 -Dapp.preferRest=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=10
@@ -65,8 +65,8 @@ spec:
             - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dconfig.override_with_env_vars=true
-                -Dapp.brokerUrl=http://benchmark-test-core:26500
-                -Dapp.brokerRestUrl=http://benchmark-test-core:8080
+                -Dapp.brokerUrl=http://camunda:26500
+                -Dapp.brokerRestUrl=http://camunda:8080
                 -Dapp.preferRest=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60

--- a/charts/zeebe-benchmark/test/golden/workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/workers.golden.yaml
@@ -3,73 +3,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: benchmark-worker
+  name: otherWorker
   labels:
-    app: benchmark-worker
+    app: otherWorker
 spec:
   selector:
     matchLabels:
-      app: benchmark-worker
-  replicas: 3
-  template:
-    metadata:
-      labels:
-        app: benchmark-worker
-        app.kubernetes.io/component: zeebe-client
-    spec:
-      containers:
-        - name: benchmark-worker
-          image: "gcr.io/zeebe-io/worker:SNAPSHOT"
-          imagePullPolicy: Always
-          env:
-            - name: JDK_JAVA_OPTIONS
-              value: >-
-                -Dconfig.override_with_env_vars=true
-                -Dapp.brokerUrl=http://benchmark-test-core:26500
-                -Dapp.brokerRestUrl=http://benchmark-test-core:8080
-                -Dapp.preferRest=false
-                -Dzeebe.client.requestTimeout=62000
-                -Dapp.worker.capacity=60
-                -Dapp.worker.threads=10
-                -Dapp.worker.pollingDelay=1ms
-                -Dapp.worker.completionDelay=50ms
-                -Dapp.worker.workerName="benchmark"
-                -Dapp.worker.jobType="benchmark-task"
-                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
-                -XX:+HeapDumpOnOutOfMemoryError
-            - name: LOG_LEVEL
-              value: "WARN"
-          resources:
-            limits:
-              cpu: 500m
-              memory: 256Mi
-            requests:
-              cpu: 500m
-              memory: 256Mi
-          ports:
-            - containerPort: 9600
-              name: "http"
----
-# Source: zeebe-benchmark/templates/workers.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: otherWorker-worker
-  labels:
-    app: otherWorker-worker
-spec:
-  selector:
-    matchLabels:
-      app: otherWorker-worker
+      app: otherWorker
   replicas: 1
   template:
     metadata:
       labels:
-        app: otherWorker-worker
+        app: otherWorker
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:
-        - name: otherWorker-worker
+        - name: otherWorker
           image: "gcr.io/zeebe-io/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
@@ -86,6 +35,57 @@ spec:
                 -Dapp.worker.workerName="otherWorker"
                 -Dapp.worker.jobType="otherWorker-job"
                 -XX:+HeapDumpOnOutOfMemoryError
+          ports:
+            - containerPort: 9600
+              name: "http"
+---
+# Source: zeebe-benchmark/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+    spec:
+      containers:
+        - name: worker
+          image: "gcr.io/zeebe-io/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.brokerUrl=http://benchmark-test-core:26500
+                -Dapp.brokerRestUrl=http://benchmark-test-core:8080
+                -Dapp.preferRest=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.pollingDelay=1ms
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "WARN"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
           ports:
             - containerPort: 9600
               name: "http"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -86,7 +86,7 @@ saas:
 # Workers configuration for the to be deployed worker application
 #        => New way to deploy workers <=
 workers:
-  benchmark:
+  worker:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 3
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
@@ -245,6 +245,7 @@ camunda-platform:
     enabled: false
 
   core:
+    fullnameOverride: camunda
     image:
       tag: "SNAPSHOT"
     ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm


### PR DESCRIPTION
During my performance investigation I stumbled over some things, which I collected in this PR

 * Change worker pod names from `benchmark-worker` to just `worker`
 * Change service name of core statefulset to `camunda` allows to simplify connection strings
    * Also good step forward to decouple Camunda Platform chart from Benchmark apps chart \cc @npepinpe 
 * Add a makefile goal to easily delete PVCs - as helm uninstall not removes them