### PR TITLE
Temporary override to fix ES url value coming from charts.

### DIFF
--- a/charts/zeebe-benchmark/templates/benchmark-config.yaml
+++ b/charts/zeebe-benchmark/templates/benchmark-config.yaml
@@ -4,4 +4,11 @@ metadata:
   name: benchmark-config
   labels: {{- include "zeebe-benchmark.labels" . | nindent 4 }}
 data:
-  benchmark-config.yaml: | {{ .Values.zeebe.config | toYaml | nindent 4 }}
+  benchmark-config.yaml: |
+    # Temporary override to fix ES url value coming from charts.
+    camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: "http://{{ .Release.Name }}-elasticsearch:9200"
+    {{- .Values.zeebe.config | toYaml | nindent 4 }}

--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -10,7 +10,13 @@ metadata:
     app.kubernetes.io/version: "8.2.5"
     app.kubernetes.io/managed-by: Helm
 data:
-  benchmark-config.yaml: | 
+  benchmark-config.yaml: |
+    # Temporary override to fix ES url value coming from charts.
+    camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: "http://benchmark-test-elasticsearch:9200"
     camunda.database.retention.enabled: "true"
     camunda.database.retention.minimumAge: 0s
     camunda.database.retention.policyName: camunda-retention-policy


### PR DESCRIPTION
This PR adds a temporary fix that is intended to be removed in the future for the value of `camunda.data.secondary-storage.elasticsearch.url`.  The value incoming from the chart is localhoast:9200, which is incorrect. 

Full discussion [here](https://camunda.slack.com/archives/C08NC7BLJ2J/p1757313458754409) and [here](https://camunda.slack.com/archives/C08E56YUUMS/p1757313758791189).