### PR TITLE
fix: case sensitivity in CamundaExporter configuration

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -186,17 +186,17 @@ zeebe:
     # Configure index suffix with hour pattern, so we create every hour a new index
     # such that ILM can clean it up quickly
     # We need to configure it for the ES exporter AND the CamundaExporter
-    zeebe.broker.exporters.CamundaExporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverInterval: "1h"
-    zeebe.broker.exporters.CamundaExporter.args.history.rolloverBatchSize: 300
-    zeebe.broker.exporters.CamundaExporter.args.history.waitPeriodBeforeArchiving: "1m"
+    zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     # We moved the archiver configuration under retention at some point, but still need to support the previous
     # versions for now, so the configurations for retention are duplicated
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
     # 0s causes ILM to move data asap - it is normally the default
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.minimumAge: "0s"
-    zeebe.broker.exporters.CamundaExporter.args.history.retention.policyName: "camunda-retention-policy"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "0s"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"
     zeebe.broker.flowControl.write.limit: 4000


### PR DESCRIPTION
 * The upstream chart is setting the exporter with `camundaexporter`
* We are configuring it with `CamundaExporter` this caused duplication of exporters because the exporter IDs are handled case sensitive, see https://github.com/camunda/camunda/issues/36444

Found via https://camunda.slack.com/archives/C0807665N8G/p1758027256318989?thread_ts=1758016016.494569&cid=C0807665N8G