### PR TITLE
Change retentition to 70m instead of 1s

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -18,7 +18,7 @@ data:
           elasticsearch:
             url: "http://benchmark-test-elasticsearch:9200"
     camunda.database.retention.enabled: "true"
-    camunda.database.retention.minimumAge: 0s
+    camunda.database.retention.minimumAge: 1h
     camunda.database.retention.policyName: camunda-retention-policy
     camunda.flags.jfr.metrics: "true"
     camunda.operate.elasticsearch.numberOfShards: 3
@@ -32,7 +32,7 @@ data:
     zeebe.broker.experimental.rocksdb.memoryLimit: 64MB
     zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: yyyy-MM-dd-HH
     zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
-    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: 0s
+    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: 1h
     zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: camunda-retention-policy
     zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
     zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: 1h

--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -18,7 +18,7 @@ data:
           elasticsearch:
             url: "http://benchmark-test-elasticsearch:9200"
     camunda.database.retention.enabled: "true"
-    camunda.database.retention.minimumAge: 1h
+    camunda.database.retention.minimumAge: 70m
     camunda.database.retention.policyName: camunda-retention-policy
     camunda.flags.jfr.metrics: "true"
     camunda.operate.elasticsearch.numberOfShards: 3
@@ -32,7 +32,7 @@ data:
     zeebe.broker.experimental.rocksdb.memoryLimit: 64MB
     zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: yyyy-MM-dd-HH
     zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
-    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: 1h
+    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: 70m
     zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: camunda-retention-policy
     zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
     zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: 1h

--- a/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-configmap.golden.yaml
@@ -110,7 +110,7 @@ data:
                 maxDelayBetweenRuns: 60000
                 retention:
                   enabled: true
-                  minimumAge: "1h"
+                  minimumAge: "70m"
                   policyName: "camunda-history-retention-policy"
                   usageMetricsMinimumAge: "730d"
                   usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
@@ -157,7 +157,7 @@ data:
         url: "http://benchmark-test-elasticsearch:9200"
         retention:
           enabled: true
-          minimumAge: "1h"
+          minimumAge: "70m"
           policyName: "camunda-history-retention-policy"
 
       #
@@ -197,7 +197,7 @@ data:
           gatewayAddress: "camunda:26500"
         archiver:
           ilmEnabled: true
-          ilmMinAgeForDeleteArchivedIndices: 1h
+          ilmMinAgeForDeleteArchivedIndices: 70m
 
       #
       # Camunda Tasklist Configuration.
@@ -241,6 +241,6 @@ data:
           restAddress: "http://camunda:8080"
         archiver:
           ilmEnabled: true
-          ilmMinAgeForDeleteArchivedIndices: 1h
+          ilmMinAgeForDeleteArchivedIndices: 70m
 
   log4j2.xml: |

--- a/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-core-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: zeebe-broker
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: d84205b4434a157c1b1f3ed00ecaaa05da45cc8916f1424e3dcdca982e91725b
+        checksum/config: 537e3048877ed1746df49a8affe5b641d181fd134b20b246da51a0cbd4f3ceaa
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -195,7 +195,7 @@ zeebe:
     zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
     # 0s causes ILM to move data asap - it is normally the default
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "1h"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "70m"
     zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"
@@ -209,7 +209,7 @@ zeebe:
     camunda.database.retention.enabled: "true"
     # 0s causes ILM to move data asap - it is normally the default
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-    camunda.database.retention.minimumAge: "1h"
+    camunda.database.retention.minimumAge: "70m"
     camunda.database.retention.policyName: "camunda-retention-policy"
     #Metrics:
     camunda.flags.jfr.metrics: "true"
@@ -321,7 +321,7 @@ camunda-platform:
         ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
         enabled: true
         ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
-        minimumAge: 1h
+        minimumAge: 70m
     # @param core.env can be used to set extra environment variables in each broker container
     env:
       # Enable JSON logging for google cloud stackdriver

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -195,7 +195,7 @@ zeebe:
     zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
     # 0s causes ILM to move data asap - it is normally the default
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "0s"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "1h"
     zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"
@@ -209,7 +209,7 @@ zeebe:
     camunda.database.retention.enabled: "true"
     # 0s causes ILM to move data asap - it is normally the default
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-    camunda.database.retention.minimumAge: "0s"
+    camunda.database.retention.minimumAge: "1h"
     camunda.database.retention.policyName: "camunda-retention-policy"
     #Metrics:
     camunda.flags.jfr.metrics: "true"


### PR DESCRIPTION
As raised in https://camunda.slack.com/archives/C09EECUGCER, when the retentition is 0s we endup recreating the index since the archiving lasts longer, which then causes that these indexes dont get cleaned after.